### PR TITLE
Existing item addition

### DIFF
--- a/packages/frontend/src/app/list/list-container/list-container.component.ts
+++ b/packages/frontend/src/app/list/list-container/list-container.component.ts
@@ -213,9 +213,14 @@ export class ListContainerComponent implements OnInit, OnDestroy {
       const trimmedValue = value.trim();
       this.listId.pipe(withLatestFrom(this.items$), take(1)).subscribe(([listId, items]) => {
         const existingValue = items.find((item) => item.name === trimmedValue);
-        existingValue
-          ? this.listService.markItemDone(listId, existingValue)
-          : this.listService.addNewItem(listId, trimmedValue);
+        if (existingValue && !existingValue.active) {
+          this.listService.markItemTodo(listId, { ...existingValue, description: null });
+          return;
+        }
+
+        if (!existingValue) {
+          this.listService.addNewItem(listId, trimmedValue);
+        }
       });
       this.inputControl.reset('', { emitEvent: true });
     }

--- a/packages/frontend/src/app/list/list-container/list-container.component.ts
+++ b/packages/frontend/src/app/list/list-container/list-container.component.ts
@@ -212,7 +212,8 @@ export class ListContainerComponent implements OnInit, OnDestroy {
     if (valid && typeof value === 'string') {
       const trimmedValue = value.trim();
       this.listId.pipe(withLatestFrom(this.items$), take(1)).subscribe(([listId, items]) => {
-        const existingValue = items.find((item) => item.name === trimmedValue);
+        const normalizedInput = trimmedValue.toLocaleLowerCase();
+        const existingValue = items.find((item) => item.name.trim().toLocaleLowerCase() === normalizedInput);
         if (existingValue && !existingValue.active) {
           this.listService.markItemTodo(listId, { ...existingValue, description: null });
           return;


### PR DESCRIPTION
Fixes an issue where existing items were not added to the list via the "Add" button.

Previously, `addItemFromInput()` incorrectly called `markItemDone()` for existing items or did nothing, instead of reactivating them. This change aligns the behavior with autocomplete selection, ensuring inactive items are reactivated and only truly new items are added.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-d95059f0-0e18-426a-bc3e-4c1ba1fdc808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d95059f0-0e18-426a-bc3e-4c1ba1fdc808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated frontend behavior change in item add flow; main risk is subtle matching/normalization edge cases affecting which item gets reactivated vs created.
> 
> **Overview**
> Fixes `addItemFromInput()` so typing an item name and clicking Add will **case/whitespace-normalize** the input, look up a matching existing item, and **reactivate it via `markItemTodo()`** when it’s currently inactive.
> 
> If no existing match is found, it continues to add a new item; the previous behavior of marking an existing match as done is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8428e16de407f432a96dffcaf09fda0952a61e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->